### PR TITLE
Fix `TypeScript`-declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 declare function hexToRgba(color: string, alpha?: string | number): string;
 
-export default hexToRgba;
+export = hexToRgba;


### PR DESCRIPTION
The `TypeScript`-declaration is erronous which prevents typescript-projects using this module from building.
The `export default` directive is the equivalent to ES6's `export default` while `export = ...` on the other hand is the equivalent to `module.exports = ..]`.