### PR TITLE
BREAKING: Drop node version 6; add node version 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
+  - "node"
   - "11"
   - "10"
   - "8"
-  - "6"


### PR DESCRIPTION
From now on, we will no longer run our tests on node 6. We will,
however, run tests on the current node version.

Node 6 has reached end of life, and node 12 has recently become the
new current version.