### PR TITLE
Add hexToRgba namespace to enable usage of this package in projects not using esModuleInterop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
 declare function hexToRgba(color: string, alpha?: string | number): string;
 
+declare namespace hexToRgba {}
+
 export = hexToRgba;


### PR DESCRIPTION
This change shouldn't be a breaking change. This just makes it so that when people import it into their typescript project it doesn't complain and the user doesn't have to set any config options.

*Before*

![Screen Shot 2020-06-11 at 11 08 15 AM](https://user-images.githubusercontent.com/1192452/84423788-e2d0b800-abd3-11ea-9927-57f67f597987.png)

*After*

![Screen Shot 2020-06-11 at 11 08 44 AM](https://user-images.githubusercontent.com/1192452/84423812-eb28f300-abd3-11ea-9240-74d8efcdaf34.png)
